### PR TITLE
Feat/2.2 agenda

### DIFF
--- a/src/main/java/com/example/eventplanner/controllers/event/EventController.java
+++ b/src/main/java/com/example/eventplanner/controllers/event/EventController.java
@@ -2,6 +2,7 @@ package com.example.eventplanner.controllers.event;
 
 import com.example.eventplanner.controllers.utils.AuthUtil;
 import com.example.eventplanner.dto.event.activity.ActivityDto;
+import com.example.eventplanner.dto.event.activity.ActivityIdDto;
 import com.example.eventplanner.dto.event.event.EventDto;
 import com.example.eventplanner.dto.event.event.EventNoIdDto;
 import com.example.eventplanner.dto.event.event.EventSummaryDto;
@@ -119,10 +120,42 @@ public class EventController {
                 new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
-    @PostMapping("/{id}/create-agenda")
+    @PostMapping("/{id}/agenda")
     public ResponseEntity<List<ActivityDto>> createAgenda(@PathVariable long id, @RequestBody List<ActivityDto> activities) {
         boolean success = eventService.createAgenda(id, activities);
         return success
+                ? ResponseEntity.ok(activities)
+                : ResponseEntity.badRequest().build();
+    }
+
+    @PostMapping("/{id}/agenda/activity")
+    public ResponseEntity<ActivityDto> addActivity(@PathVariable long id, @RequestBody ActivityDto activity) {
+        boolean success = eventService.addActivity(id, activity);
+        return success
+                ? ResponseEntity.ok(activity)
+                : ResponseEntity.badRequest().build();
+    }
+
+    @PutMapping("/{id}/agenda/activity/{activityId}")
+    public ResponseEntity<ActivityDto> updateActivity(@PathVariable long id, @PathVariable long activityId, @RequestBody ActivityDto activity) {
+        boolean success = eventService.updateActivity(id, activityId, activity);
+        return success
+                ? ResponseEntity.ok(activity)
+                : ResponseEntity.badRequest().build();
+    }
+
+    @DeleteMapping("/{id}/agenda/activity/{activityId}")
+    public ResponseEntity deleteActivity(@PathVariable long id, @PathVariable long activityId) {
+        boolean success = eventService.deleteActivity(id, activityId);
+        return success
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/{id}/agenda")
+    public ResponseEntity<List<ActivityIdDto>> getAgenda(@PathVariable long id) {
+        List<ActivityIdDto> activities = eventService.getAgenda(id);
+        return activities != null
                 ? ResponseEntity.ok(activities)
                 : ResponseEntity.badRequest().build();
     }

--- a/src/main/java/com/example/eventplanner/controllers/event/EventController.java
+++ b/src/main/java/com/example/eventplanner/controllers/event/EventController.java
@@ -145,11 +145,11 @@ public class EventController {
     }
 
     @DeleteMapping("/{id}/agenda/activity/{activityId}")
-    public ResponseEntity deleteActivity(@PathVariable long id, @PathVariable long activityId) {
+    public ResponseEntity<Void> deleteActivity(@PathVariable long id, @PathVariable long activityId) {
         boolean success = eventService.deleteActivity(id, activityId);
         return success
                 ? ResponseEntity.noContent().build()
-                : ResponseEntity.badRequest().build();
+                : ResponseEntity.notFound().build();
     }
 
     @GetMapping("/{id}/agenda")
@@ -157,7 +157,7 @@ public class EventController {
         List<ActivityIdDto> activities = eventService.getAgenda(id);
         return activities != null
                 ? ResponseEntity.ok(activities)
-                : ResponseEntity.badRequest().build();
+                : ResponseEntity.notFound().build();
     }
 
     @GetMapping(value = "/{id}/purchases")

--- a/src/main/java/com/example/eventplanner/dto/event/activity/ActivityIdDto.java
+++ b/src/main/java/com/example/eventplanner/dto/event/activity/ActivityIdDto.java
@@ -1,21 +1,16 @@
-package com.example.eventplanner.model.event;
+package com.example.eventplanner.dto.event.activity;
 
-import com.example.eventplanner.model.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.SQLRestriction;
-
-import java.util.Date;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@SQLRestriction("active = true")
-@jakarta.persistence.Entity
-public class Activity extends Entity {
+public class ActivityIdDto {
+    private long id;
     private String name;
     private long activityStart;
     private long activityEnd;

--- a/src/main/java/com/example/eventplanner/dto/event/activity/ActivityMapper.java
+++ b/src/main/java/com/example/eventplanner/dto/event/activity/ActivityMapper.java
@@ -12,8 +12,22 @@ public class ActivityMapper {
 
         return new ActivityDto(
                 activity.getName(),
-                activity.getActivityStart().getTime(),
-                activity.getActivityEnd().getTime(),
+                activity.getActivityStart(),
+                activity.getActivityEnd(),
+                activity.getDescription(),
+                activity.getLocation()
+        );
+    }
+
+    public static ActivityIdDto toIdDto(Activity activity) {
+        if (activity == null)
+            return null;
+
+        return new ActivityIdDto(
+                activity.getId(),
+                activity.getName(),
+                activity.getActivityStart(),
+                activity.getActivityEnd(),
                 activity.getDescription(),
                 activity.getLocation()
         );
@@ -24,8 +38,8 @@ public class ActivityMapper {
 
         Activity activity = new Activity(
                 dto.getName(),
-                new Date(dto.getActivityStart()),
-                new Date(dto.getActivityEnd()),
+                dto.getActivityStart(),
+                dto.getActivityEnd(),
                 dto.getDescription(),
                 dto.getLocation());
         activity.setActive(true);

--- a/src/main/java/com/example/eventplanner/model/event/Activity.java
+++ b/src/main/java/com/example/eventplanner/model/event/Activity.java
@@ -1,6 +1,7 @@
 package com.example.eventplanner.model.event;
 
 import com.example.eventplanner.model.Entity;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/eventplanner/model/event/Event.java
+++ b/src/main/java/com/example/eventplanner/model/event/Event.java
@@ -2,16 +2,14 @@ package com.example.eventplanner.model.event;
 
 import com.example.eventplanner.model.Entity;
 import com.example.eventplanner.model.user.EventOrganizer;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 

--- a/src/main/java/com/example/eventplanner/services/event/EventService.java
+++ b/src/main/java/com/example/eventplanner/services/event/EventService.java
@@ -9,6 +9,7 @@ import com.example.eventplanner.dto.event.event.EventNoIdDto;
 import com.example.eventplanner.dto.event.event.EventSummaryDto;
 import com.example.eventplanner.dto.order.booking.BookingDto;
 import com.example.eventplanner.dto.order.purchase.PurchaseDto;
+import com.example.eventplanner.model.Entity;
 import com.example.eventplanner.model.event.Activity;
 import com.example.eventplanner.model.event.Event;
 import com.example.eventplanner.model.event.EventType;
@@ -179,7 +180,13 @@ public class EventService {
     public List<ActivityIdDto> getAgenda(long id) {
         Event event = eventRepository.findById(id).orElse(null);
         if (event == null) return null;
-        return event.getActivities().stream().map(ActivityMapper::toIdDto).sorted(Comparator.comparing(ActivityIdDto::getActivityStart)).toList();
+        return event
+                .getActivities()
+                .stream()
+                .filter(Entity::isActive)
+                .map(ActivityMapper::toIdDto)
+                .sorted(Comparator.comparing(ActivityIdDto::getActivityStart))
+                .toList();
     }
 
     public boolean updateActivity(long eventId, long activityId, ActivityDto dto) {
@@ -208,26 +215,24 @@ public class EventService {
     public boolean deleteActivity(long eventId, long activityId) {
         Event event = eventRepository.findById(eventId).orElse(null);
         if (event == null) return false;
-
-        boolean removed = event.getActivities().removeIf(a -> a.getId() == activityId);
-        if (removed) {
-            eventRepository.save(event);
+        Activity activity = event.getActivities().stream().filter(a -> a.getId() == activityId).findFirst().orElse(null);
+        if (activity != null) {
+            activity.setActive(false);
         }
-        return removed;
+        eventRepository.save(event);
+        return activity != null;
     }
 
     private boolean isTimeValid(List<Activity> activities, long start, long end, Long activityId) {
         if (start >= end) return false;
 
-        for (Activity activity : activities) {
+        for (Activity activity : activities.stream().filter(Entity::isActive).toList()) {
             if (activityId != null && activity.getId() == activityId) continue;
 
             long existingStart = activity.getActivityStart();
             long existingEnd = activity.getActivityEnd();
 
-            boolean overlaps = (start < existingEnd && end > existingStart) ||
-                    (existingStart < end && existingEnd > start) ||
-                    (start == existingStart && end == existingEnd);
+            boolean overlaps = start < existingEnd && end > existingStart;
 
             if (overlaps) return false;
         }

--- a/src/main/java/com/example/eventplanner/services/event/EventService.java
+++ b/src/main/java/com/example/eventplanner/services/event/EventService.java
@@ -170,6 +170,7 @@ public class EventService {
     public boolean addActivity(long id, ActivityDto activity) {
         Event event = eventRepository.findById(id).orElse(null);
         if (event == null) return false;
+        if (!isTimeValid(event.getActivities(), activity.getActivityStart(), activity.getActivityEnd(), null)) return false;
         event.getActivities().add(ActivityMapper.toEntity(activity));
         eventRepository.save(event);
         return true;
@@ -184,6 +185,8 @@ public class EventService {
     public boolean updateActivity(long eventId, long activityId, ActivityDto dto) {
         Event event = eventRepository.findById(eventId).orElse(null);
         if (event == null) return false;
+
+        if (!isTimeValid(event.getActivities(), dto.getActivityStart(), dto.getActivityEnd(), activityId)) return false;
 
         Optional<Activity> optionalActivity = event.getActivities().stream()
                 .filter(a -> a.getId() == activityId)
@@ -202,7 +205,6 @@ public class EventService {
         return true;
     }
 
-
     public boolean deleteActivity(long eventId, long activityId) {
         Event event = eventRepository.findById(eventId).orElse(null);
         if (event == null) return false;
@@ -212,6 +214,25 @@ public class EventService {
             eventRepository.save(event);
         }
         return removed;
+    }
+
+    private boolean isTimeValid(List<Activity> activities, long start, long end, Long activityId) {
+        if (start >= end) return false;
+
+        for (Activity activity : activities) {
+            if (activityId != null && activity.getId() == activityId) continue;
+
+            long existingStart = activity.getActivityStart();
+            long existingEnd = activity.getActivityEnd();
+
+            boolean overlaps = (start < existingEnd && end > existingStart) ||
+                    (existingStart < end && existingEnd > start) ||
+                    (start == existingStart && end == existingEnd);
+
+            if (overlaps) return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/main/java/com/example/eventplanner/services/event/EventService.java
+++ b/src/main/java/com/example/eventplanner/services/event/EventService.java
@@ -1,6 +1,7 @@
 package com.example.eventplanner.services.event;
 
 import com.example.eventplanner.dto.event.activity.ActivityDto;
+import com.example.eventplanner.dto.event.activity.ActivityIdDto;
 import com.example.eventplanner.dto.event.activity.ActivityMapper;
 import com.example.eventplanner.dto.event.event.EventDto;
 import com.example.eventplanner.dto.event.event.EventMapper;
@@ -165,4 +166,52 @@ public class EventService {
         Integer max = (Integer) result.get(0)[1];
         return Arrays.asList(min, max);
     }
+
+    public boolean addActivity(long id, ActivityDto activity) {
+        Event event = eventRepository.findById(id).orElse(null);
+        if (event == null) return false;
+        event.getActivities().add(ActivityMapper.toEntity(activity));
+        eventRepository.save(event);
+        return true;
+    }
+
+    public List<ActivityIdDto> getAgenda(long id) {
+        Event event = eventRepository.findById(id).orElse(null);
+        if (event == null) return null;
+        return event.getActivities().stream().map(ActivityMapper::toIdDto).sorted(Comparator.comparing(ActivityIdDto::getActivityStart)).toList();
+    }
+
+    public boolean updateActivity(long eventId, long activityId, ActivityDto dto) {
+        Event event = eventRepository.findById(eventId).orElse(null);
+        if (event == null) return false;
+
+        Optional<Activity> optionalActivity = event.getActivities().stream()
+                .filter(a -> a.getId() == activityId)
+                .findFirst();
+
+        if (optionalActivity.isEmpty()) return false;
+
+        Activity activity = optionalActivity.get();
+        activity.setName(dto.getName());
+        activity.setActivityStart(dto.getActivityStart());
+        activity.setActivityEnd(dto.getActivityEnd());
+        activity.setDescription(dto.getDescription());
+        activity.setLocation(dto.getLocation());
+
+        eventRepository.save(event);
+        return true;
+    }
+
+
+    public boolean deleteActivity(long eventId, long activityId) {
+        Event event = eventRepository.findById(eventId).orElse(null);
+        if (event == null) return false;
+
+        boolean removed = event.getActivities().removeIf(a -> a.getId() == activityId);
+        if (removed) {
+            eventRepository.save(event);
+        }
+        return removed;
+    }
+
 }


### PR DESCRIPTION
This pull request introduces enhancements to the event management system, focusing on managing activities within event agendas. The changes include new CRUD operations for activities, the addition of a DTO for activity IDs, and updates to the `Activity` model to simplify time handling. These improvements enhance functionality, maintainability, and clarity in the codebase.

### New Features for Managing Activities:
* Added CRUD endpoints in `EventController` for activities within an event's agenda, including adding, updating, deleting, and retrieving activities. (`[src/main/java/com/example/eventplanner/controllers/event/EventController.javaL122-R162](diffhunk://#diff-c0ab37d131e93cd8d067332e9324c8570a141c8439fbcb944851d3ba1528c326L122-R162)`)
* Introduced `ActivityIdDto` to include activity metadata (e.g., ID, name, time, description, location) for agenda-related operations. (`[src/main/java/com/example/eventplanner/dto/event/activity/ActivityIdDto.javaR1-R19](diffhunk://#diff-c8d1a5042dadfe40074704f0c25a9953b0a76d6575e3532c8259a672866590b6R1-R19)`)
* Implemented corresponding service methods in `EventService` for handling activity operations, including time conflict validation. (`[src/main/java/com/example/eventplanner/services/event/EventService.javaR169-R237](diffhunk://#diff-987bc275b2d2a1fb8995bc11430ca3d8e295d23950e6353fe8388ce9d0b9aa41R169-R237)`)

### Codebase Simplification:
* Updated the `Activity` model to use `long` for `activityStart` and `activityEnd` instead of `Date`, simplifying time handling. (`[src/main/java/com/example/eventplanner/model/event/Activity.javaL20-R21](diffhunk://#diff-7b33046b40411d4aace7d1178a115828fdfb2082e5cda422a8a2b65f23b68a88L20-R21)`)
* Added `toIdDto` method in `ActivityMapper` to convert `Activity` entities to `ActivityIdDto`. Refactored existing `toDto` and `toEntity` methods to align with the updated `Activity` model. (`[[1]](diffhunk://#diff-042d6d3f239f2036ebaa77f8b3e79aacc33b8765554a62e6f8ee3b0c191b7156L15-R30)`, `[[2]](diffhunk://#diff-042d6d3f239f2036ebaa77f8b3e79aacc33b8765554a62e6f8ee3b0c191b7156L27-R42)`)