### PR TITLE
Feat/2.4 pdf service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
 			<version>2.9.0</version>
 		</dependency>
 		<dependency>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openpdf</artifactId>
+			<version>1.3.32</version>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/com/example/eventplanner/controllers/auth/AuthController.java
+++ b/src/main/java/com/example/eventplanner/controllers/auth/AuthController.java
@@ -39,7 +39,10 @@ public class AuthController {
 
         String token = jwtTokenUtil.generateToken(authenticatedUser.getEmail());
 
-        return new LoginResponseDto(authenticatedUser.getId(), authenticatedUser.getEmail(), token);
+        return new LoginResponseDto(authenticatedUser.getId(),
+                authenticatedUser.getEmail(),
+                token,
+                authenticatedUser.getUserRole());
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/example/eventplanner/controllers/event/EventController.java
+++ b/src/main/java/com/example/eventplanner/controllers/event/EventController.java
@@ -9,11 +9,14 @@ import com.example.eventplanner.dto.event.event.EventSummaryDto;
 import com.example.eventplanner.dto.order.booking.BookingDto;
 import com.example.eventplanner.dto.order.purchase.PurchaseDto;
 import com.example.eventplanner.model.user.EventOrganizer;
+import com.example.eventplanner.services.event.EventReportService;
 import com.example.eventplanner.services.event.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,7 +29,8 @@ import java.util.List;
 public class EventController {
     private final EventService eventService;
     private final AuthUtil authUtil;
-    
+    private final EventReportService eventReportService;
+
     @GetMapping
     public ResponseEntity<Page<EventDto>> getAllEvents(
             @RequestParam(defaultValue = "0") int page,
@@ -118,6 +122,15 @@ public class EventController {
         return result != null ?
                 new ResponseEntity<>(result, HttpStatus.OK) :
                 new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
+    @GetMapping("/{id}/pdf")
+    public ResponseEntity<byte[]> getEventPdf(@PathVariable Long id) throws Exception {
+        byte[] pdf = eventReportService.generateEventPdf (id);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=event_" + id + ".pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
     }
 
     @PostMapping("/{id}/agenda")

--- a/src/main/java/com/example/eventplanner/dto/auth/LoginResponseDto.java
+++ b/src/main/java/com/example/eventplanner/dto/auth/LoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.eventplanner.dto.auth;
 
+import com.example.eventplanner.model.utils.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,4 +14,5 @@ public class LoginResponseDto {
     private Long id;
     private String email;
     private String jwt;
+    private UserRole role;
 }

--- a/src/main/java/com/example/eventplanner/services/event/EventReportService.java
+++ b/src/main/java/com/example/eventplanner/services/event/EventReportService.java
@@ -1,0 +1,77 @@
+package com.example.eventplanner.services.event;
+
+import com.example.eventplanner.dto.event.event.EventDto;
+import com.example.eventplanner.dto.event.event.EventMapper;
+import com.example.eventplanner.model.event.Activity;
+import com.example.eventplanner.model.event.Event;
+import com.example.eventplanner.repositories.event.EventRepository;
+import com.lowagie.text.*;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
+import java.util.TimeZone;
+
+@Service
+public class EventReportService {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    public byte[] generateEventPdf(long id) {
+        Event event = eventRepository.findById(id).orElseThrow();
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Document document = new Document();
+            PdfWriter.getInstance(document, out);
+            document.open();
+
+            document.add(new Paragraph("Event: " + event.getName()));
+            document.add(new Paragraph("Description: " + event.getDescription()));
+            document.add(new Paragraph("Type: " + event.getType().getName()));
+            document.add(new Paragraph("Organizer: " + event.getEventOrganizer().getFirstName()));
+            document.add(new Paragraph("Max Attendances: " + event.getMaxAttendances()));
+            document.add(new Paragraph("Open: " + (event.isOpen() ? "Yes" : "No")));
+            document.add(new Paragraph("Date: " + event.getDate().toString().split(" ")[0]));
+
+            document.add(new Paragraph("\nActivities:"));
+
+            PdfPTable table = new PdfPTable(4);
+            table.setWidthPercentage(100);
+            table.setSpacingBefore(10f);
+            table.setSpacingAfter(10f);
+
+            table.addCell(new PdfPCell(new Phrase("Name")));
+            table.addCell(new PdfPCell(new Phrase("Time")));
+            table.addCell(new PdfPCell(new Phrase("Description")));
+            table.addCell(new PdfPCell(new Phrase("Location")));
+
+            for (Activity a : event.getActivities()) {
+                table.addCell(a.getName());
+                table.addCell(formatMillisToTime(a.getActivityStart()) + " - " + formatMillisToTime(a.getActivityEnd()));
+                table.addCell(a.getDescription());
+                table.addCell(a.getLocation());
+            }
+
+            document.add(table);
+
+            document.close();
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("Error generating PDF", e);
+        }
+    }
+
+    public static String formatMillisToTime(long millis) {
+        long totalMinutes = millis / (1000 * 60);
+        long hours = totalMinutes / 60;
+        long minutes = totalMinutes % 60;
+        return String.format("%02d:%02d", hours, minutes);
+    }
+
+}

--- a/src/main/java/com/example/eventplanner/services/event/EventReportService.java
+++ b/src/main/java/com/example/eventplanner/services/event/EventReportService.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Optional;
@@ -38,6 +40,17 @@ public class EventReportService {
             document.add(new Paragraph("Max Attendances: " + event.getMaxAttendances()));
             document.add(new Paragraph("Open: " + (event.isOpen() ? "Yes" : "No")));
             document.add(new Paragraph("Date: " + event.getDate().toString().split(" ")[0]));
+            String googleMapsUrl = "https://www.google.com/maps/search/?api=1&query="
+                    + event.getLatitude() + "," + event.getLongitude();
+
+            Anchor eventLocationLink = new Anchor(
+                    "Click the link"
+            );
+            eventLocationLink.setReference(googleMapsUrl);
+
+            Paragraph locationParagraph = new Paragraph("Location: ");
+            locationParagraph.add(eventLocationLink);
+            document.add(locationParagraph);
 
             document.add(new Paragraph("\nActivities:"));
 
@@ -55,7 +68,11 @@ public class EventReportService {
                 table.addCell(a.getName());
                 table.addCell(formatMillisToTime(a.getActivityStart()) + " - " + formatMillisToTime(a.getActivityEnd()));
                 table.addCell(a.getDescription());
-                table.addCell(a.getLocation());
+                //table.addCell(a.getLocation());
+                Anchor locationLink = new Anchor(a.getLocation());
+                locationLink.setReference("https://www.google.com/maps/search/?api=1&query=" +
+                        URLEncoder.encode(a.getLocation(), StandardCharsets.UTF_8));
+                table.addCell(locationLink);
             }
 
             document.add(table);


### PR DESCRIPTION
This pull request introduces a new feature for generating downloadable PDF reports of event details, including activities, and integrates it into the event controller. The main changes include adding a PDF generation library, implementing the `EventReportService` for PDF creation, and exposing a new endpoint for retrieving event PDFs.

**PDF Generation Feature:**

* Added the `openpdf` library dependency to `pom.xml` to enable PDF creation functionality.
* Implemented the new `EventReportService` in `src/main/java/com/example/eventplanner/services/event/EventReportService.java`, which generates a PDF containing event details and a table of activities, with location links to Google Maps.

**Controller Integration:**

* Injected `EventReportService` into `EventController` and added necessary imports for PDF response handling. [[1]](diffhunk://#diff-c0ab37d131e93cd8d067332e9324c8570a141c8439fbcb944851d3ba1528c326R12-R19) [[2]](diffhunk://#diff-c0ab37d131e93cd8d067332e9324c8570a141c8439fbcb944851d3ba1528c326R32)
* Added a new endpoint `GET /events/{id}/pdf` in `EventController` that returns the generated PDF as a downloadable file.