### PR TITLE
Hotfix - endpoint security

### DIFF
--- a/src/main/java/com/example/eventplanner/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/example/eventplanner/config/WebSecurityConfiguration.java
@@ -141,7 +141,7 @@ public class WebSecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/reviews/pending").hasRole("ADMIN")
 
                         // Everything else requires authentication
-                        .anyRequest().permitAll())
+                        .anyRequest().authenticated())
                 .sessionManagement(session -> {
                     session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
                 })


### PR DESCRIPTION
All not-covered branches were left with permitAll.